### PR TITLE
Make ActivationResultMessage public

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abap-adt-api",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "description": "Interface to Abap Developer Tools webservice",
   "outDir": "build",
   "main": "build/index.js",

--- a/src/api/activate.ts
+++ b/src/api/activate.ts
@@ -10,16 +10,16 @@ export interface InactiveObject {
   "adtcore:name": string
   "adtcore:parentUri": string
 }
-interface InactiveObjectElement extends InactiveObject {
+export interface InactiveObjectElement extends InactiveObject {
   user: string
   deleted: boolean
 }
-interface InactiveObjectRecord {
+export interface InactiveObjectRecord {
   object?: InactiveObjectElement
   transport?: InactiveObjectElement
 }
 
-interface ActivationResultMessage {
+export interface ActivationResultMessage {
   objDescr: string
   type: string
   line: number


### PR DESCRIPTION
Making types used inside other "export" types also "export" makes the live for users a little bit easier.