### PR TITLE
feat(revisions): add `revisionContent()` to fetch historical source versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+
+- `revisionContent(contentUri)`: fetches the ABAP source of a specific historical revision via the ADT versioned content endpoint
+
 ## 5.2.0 [2023-11-06]
 
 ### Added

--- a/restcalls/revisions.http
+++ b/restcalls/revisions.http
@@ -1,3 +1,14 @@
+### Enhancement version history investigation (April 2026)
+# CL_SEEF_ADT_RES_ENHANCEMENTS only exposes a single GET handler with no /versions
+# sub-path and no version= query param support.  The endpoint below will 404 on
+# all known systems — documented here so future agents don't re-investigate.
+#
+# GET {{baseUrl}}/sap/bc/adt/programs/includes/{{include}}/source/main/enhancements/versions
+#
+# Workaround: ENHO objects DO have standard ADT version history via their own source:
+#   GET /sap/bc/adt/enhancements/implementations/{{enho_name}}/source/main/versions
+# and individual content via the standard revisionContent() API added in this branch.
+
 ### abapgit_old
 GET {{baseUrl}}/sap/bc/adt/programs/programs/zabapgit_old/source/main/versions
 Authorization: Basic {{user}}:{{password}}

--- a/src/AdtClient.ts
+++ b/src/AdtClient.ts
@@ -135,6 +135,7 @@ import {
   RegistrationInfo,
   remoteRepoInfo,
   Revision,
+  revisionContent,
   renameEvaluate,
   renamePreview,
   renameExecute,
@@ -986,6 +987,10 @@ export class ADTClient {
     clsInclude?: classIncludes
   ) {
     return revisions(this.h, objectUrl, clsInclude)
+  }
+
+  public revisionContent(contentUri: string) {
+    return revisionContent(this.h, contentUri)
   }
 
   public objectEnhancements(

--- a/src/api/revisions.ts
+++ b/src/api/revisions.ts
@@ -88,3 +88,24 @@ export async function revisions(
   )
   return versions
 }
+
+/**
+ * Fetches the ABAP source code of a specific historical revision.
+ *
+ * The `contentUri` should be the `uri` field from a `Revision` object returned
+ * by `revisions()` — it points to the ADT versioned content endpoint:
+ *   GET .../versions/<timestamp>/<seq>/content
+ *
+ * @param h           ADT HTTP client
+ * @param contentUri  The `Revision.uri` value from a prior `revisions()` call
+ * @returns           The ABAP source at that historical revision as a plain string
+ */
+export async function revisionContent(
+  h: AdtHTTP,
+  contentUri: string
+): Promise<string> {
+  const response = await h.request(contentUri, {
+    headers: { Accept: "text/plain" }
+  })
+  return response.body as string
+}

--- a/src/test/main.test.ts
+++ b/src/test/main.test.ts
@@ -1267,6 +1267,38 @@ test(
 )
 
 test(
+  "revision content for func",
+  runTest(async (c: ADTClient) => {
+    jest.setTimeout(15000) // versioned content fetch can be slow
+    const obj =
+      "/sap/bc/adt/functions/groups/zapidummyfoobar/fmodules/zapidummyfoofunc"
+    const revs = await c.revisions(obj)
+    expect(revs).toBeTruthy()
+    if (!revs[0]?.uri) return // no versions on this system
+    const source = await c.revisionContent(revs[0].uri).catch(eat404)
+    if (!source) return // endpoint not supported on this system
+    expect(typeof source).toBe("string")
+    expect(source.length).toBeGreaterThan(0)
+  })
+)
+
+test(
+  "revision content for class include",
+  runTest(async (c: ADTClient) => {
+    jest.setTimeout(15000) // versioned content fetch can be slow
+    const obj = "/sap/bc/adt/oo/classes/zapiadt_testcase_class1"
+    const revs = await c.revisions(obj, "main")
+    expect(revs).toBeTruthy()
+    const firstWithUri = revs.find(r => !!r.uri)
+    if (!firstWithUri) return // no versions on this system
+    const source = await c.revisionContent(firstWithUri.uri).catch(eat404)
+    if (!source) return // endpoint not supported on this system
+    expect(typeof source).toBe("string")
+    expect(source.length).toBeGreaterThan(0)
+  })
+)
+
+test(
   "objectEnhancements",
   runTest(async (c: ADTClient) => {
     // zapidummyfoobar is always present in the test system


### PR DESCRIPTION
**Description**
- **Summary:** Adds `revisionContent(contentUri)` to the revisions API and exposes `ADTClient.revisionContent()` so tools can fetch the plain-text ABAP source for a historical snapshot (ADT `/versions/<timestamp>/<seq>/content`).
- **Why:** Enables consumers to read historical object source (revision history) without bringing unrelated changes from the original feature branch.
- **What changed:** Implements the revisions endpoint call, exposes the client method, and includes docs + integration tests (extracted as a focused change).
- **How to validate:** 
  - Run: `npm ci`  
  - Build: `npm run build`  
  - Tests: `npm test` (note: test backend was not available during the tests)
- **Notes:** Extracted from `feature/revision-content` (backup: `feature/revision-content.bak`, commit `eb962ec`). Target branch is `upstream/master`. Please mention PR #43 in the PR description for context.