### PR TITLE
Support OData V4 service bindings and honor the category option

### DIFF
--- a/src/api/objectcreator.ts
+++ b/src/api/objectcreator.ts
@@ -95,15 +95,20 @@ export interface NewPackageOptions
 }
 
 export type BindingCategory = "0" | "1"
+export type BindingVersion = "V2" | "V4"
 export const BindinTypes = [
-  { description: "Odata V2 - Web API", bindingtype: "ODATA", category: "0" },
-  { description: "Odata V2 - UI", bindingtype: "ODATA", category: "1" }
+  { description: "Odata V2 - Web API", bindingtype: "ODATA", category: "0", version: "V2" },
+  { description: "Odata V2 - UI", bindingtype: "ODATA", category: "1", version: "V2" },
+  { description: "Odata V4 - Web API", bindingtype: "ODATA", category: "0", version: "V4" },
+  { description: "Odata V4 - UI", bindingtype: "ODATA", category: "1", version: "V4" }
 ]
+export const BindingTypes = BindinTypes
 export interface NewBindingOptions extends NewObjectOptions {
   objtype: BindingTypeId
   service: string
   bindingtype: "ODATA"
   category: BindingCategory
+  bindingVersion?: BindingVersion
 }
 
 export const hasPackageOptions = (o: any): o is PackageSpecificData =>
@@ -203,13 +208,15 @@ function createBodySimple(
 }
 
 function createBodyBinding(options: NewBindingOptions, type: CreatableType) {
+  const category = options.category ?? "0"
+  const bindingVersion = options.bindingVersion ?? "V2"
   const body = `<adtcore:packageRef adtcore:name="${options.parentName}"/>
       <srvb:services srvb:name="${options.name}">
           <srvb:content srvb:version="0001">
               <srvb:serviceDefinition adtcore:name="${options.service}"/>
           </srvb:content>
       </srvb:services>
-      <srvb:binding srvb:category="0" srvb:type="${options.bindingtype}" srvb:version="V2">
+      <srvb:binding srvb:category="${category}" srvb:type="${options.bindingtype}" srvb:version="${bindingVersion}">
           <srvb:implementation adtcore:name=""/>
       </srvb:binding>`
   return createBodySimple(options, type, body)

--- a/src/api/objectcreator.ts
+++ b/src/api/objectcreator.ts
@@ -97,10 +97,10 @@ export interface NewPackageOptions
 export type BindingCategory = "0" | "1"
 export type BindingVersion = "V2" | "V4"
 export const BindinTypes = [
-  { description: "Odata V2 - Web API", bindingtype: "ODATA", category: "0", version: "V2" },
-  { description: "Odata V2 - UI", bindingtype: "ODATA", category: "1", version: "V2" },
-  { description: "Odata V4 - Web API", bindingtype: "ODATA", category: "0", version: "V4" },
-  { description: "Odata V4 - UI", bindingtype: "ODATA", category: "1", version: "V4" }
+  { description: "Odata V2 - UI", bindingtype: "ODATA", category: "0", version: "V2" },
+  { description: "Odata V2 - Web API", bindingtype: "ODATA", category: "1", version: "V2" },
+  { description: "Odata V4 - UI", bindingtype: "ODATA", category: "0", version: "V4" },
+  { description: "Odata V4 - Web API", bindingtype: "ODATA", category: "1", version: "V4" }
 ]
 export const BindingTypes = BindinTypes
 export interface NewBindingOptions extends NewObjectOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ export {
   BindingServiceNavigation,
   BindingServiceResult,
   BindinTypes,
+  BindingTypes,
+  BindingVersion,
   BindingValidationOptions,
   ClassComponent,
   ClassInclude,

--- a/src/test/main.test.ts
+++ b/src/test/main.test.ts
@@ -1623,6 +1623,22 @@ test("type validation for service binding options", () => {
   expect(isBindingOptions(testdata)).toBe(true)
 })
 
+test("type validation for V4 UI service binding options", () => {
+  const testdata: NewObjectOptions | NewBindingOptions = {
+    description: "f",
+    name: "YMU_BFOO",
+    objtype: "SRVB/SVB",
+    parentName: "YMU_RAP_TRAVEL",
+    parentPath: "/sap/bc/adt/packages/YMU_RAP_TRAVEL",
+    responsible: "CB0000000083",
+    bindingtype: "ODATA",
+    category: "1",
+    bindingVersion: "V4",
+    service: "YMU_RAP_UI_TRAVEL"
+  }
+  expect(isBindingOptions(testdata)).toBe(true)
+})
+
 test(
   "feed list",
   runTest(async (c: ADTClient) => {


### PR DESCRIPTION
## Why

`createBodyBinding` in `src/api/objectcreator.ts` hardcodes
`srvb:version="V2"` and `srvb:category="0"` in the XML body sent to
`/sap/bc/adt/businessservices/bindings`. This has two consequences:

1. **OData V4 service bindings cannot be created at all** through
   `createObject`. RAP projects targeting V4 (a common case for newer
   S/4HANA Cloud / private cloud setups) need this.
2. **The `category` option on `NewBindingOptions` is silently
   ignored.** `NewBindingOptions` already exposes a
   `category: "0" | "1"` field, but `createBodyBinding` ignores it —
   every call ends up as `category="0"` regardless. So calling
   `createObject` with `category: "1"` today produces the same wire
   output as `category: "0"`.

Both issues live in the same function and have the same root cause
(hardcoded XML attributes), so they are fixed together.

## What

- `createBodyBinding` now reads `options.category` (defaults to `"0"`)
  and a new optional `options.bindingVersion` (`"V2" | "V4"`, defaults
  to `"V2"`).
- `NewBindingOptions` gains an optional `bindingVersion` field.
- The `BindinTypes` catalog is extended with V4 Web API and V4 UI
  entries; every entry now also carries a `version` property so
  consumers can drive UI selectors from a single source of truth.
- A `BindingTypes` alias is exported alongside `BindinTypes` to
  smooth over the typo in the original name; the original export is
  kept so existing imports don't break.
- New type `BindingVersion` is exported.

## Catalog label correction (commit 2)

The original `BindinTypes` catalog labeled `category="0"` as
"Web API" and `category="1"` as "UI". This is reversed relative to
what SAP ADT actually emits and accepts. The label was previously
masked by the hardcoded `srvb:category="0"` in `createBodyBinding`:
every binding came out as `category="0"` regardless of the value
passed in `options.category`, and `category="0"` happens to be UI
(the common case), so nobody noticed.

Now that `createBodyBinding` honors `options.category`, callers that
trust the catalog labels would otherwise send the wrong wire value.
This commit fixes the labels to match SAP semantics:

| category | meaning |
|----------|---------|
| `"0"`    | UI (Fiori Elements, OData V2/V4 UI service) |
| `"1"`    | Web API (OData V2/V4 Web API)               |

Confirmed against:

- Real SAP `*.srvbsvb` files in the wild (multiple V2 UI and V4 UI
  bindings, all `category="0"`).
- This repo's own `parse service binding` test fixture (V2 UI
  binding `YMU_RAP_UI_TRAVEL_O2` with `srvb:category="0"`).
- An independent SRVB-create implementation (`marianfoo/arc-1`) that
  documents the same mapping and was validated end-to-end on a live
  S/4HANA system.

Wire output for an explicit `category` argument is unchanged. Only
the catalog labels move.

## Backward compatibility

- All new fields are optional. Callers that pass neither `category`
  nor `bindingVersion` keep emitting the exact same XML as before
  (`srvb:category="0" srvb:type="ODATA" srvb:version="V2"`, which
  per the corrected labels above is V2 UI).
- `BindinTypes` (typo) export is preserved.
- The new `version` property on catalog entries is purely additive.

## Note for users creating SRVBs programmatically

Service bindings are metadata-only: `createObject` (POST to
`/sap/bc/adt/businessservices/bindings`) registers the SRVD reference
and binding type/version/category in one call, and there is no
`/source/main` endpoint to push afterwards. Callers that want to
activate a freshly-created binding should use
`/sap/bc/adt/businessservices/bindings/{name}` as the URI for the
`activate` call; SRVBs are not stored under
`/sap/bc/adt/ddic/srvb/sources/...`.

## Tests

- `tsc` clean.
- `jest -t "type validation"` — both the existing V2 and the new V4
  UI type-guard tests pass.
- Verified end-to-end against a live S/4HANA system: a V4 UI binding
  created with `bindingVersion: "V4"`, `category: "0"` is registered
  and activates successfully via
  `/sap/bc/adt/businessservices/bindings/{name}`. V2 callers using
  defaults are unaffected.

## Files changed

- `src/api/objectcreator.ts` — catalog, type, body builder
- `src/index.ts` — re-exports for `BindingTypes`, `BindingVersion`
- `src/test/main.test.ts` — V4 UI type-guard test